### PR TITLE
[daint] Packages for nest. Fake intel compiler for profiling

### DIFF
--- a/daint/compilers.yaml
+++ b/daint/compilers.yaml
@@ -155,6 +155,24 @@ compilers:
     flags: {}
     modules:
     - PrgEnv-intel
+    - perftools-base
+    - perftools
+    - !!python/unicode 'intel/17.0.0.098'
+    operating_system: CNL
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@17.0.0.999
+    target: any
+
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
     - !!python/unicode 'intel/16.0.3.210'
     operating_system: CNL
     paths:

--- a/daint/packages.yaml
+++ b/daint/packages.yaml
@@ -2,6 +2,7 @@ packages:
     mpich:
         modules:
             mpich@7.5.0%intel@17.0.0.098 arch=cray-CNL-haswell: cray-mpich/7.5.0
+            mpich@7.5.0%intel@17.0.0.999 arch=cray-CNL-haswell: cray-mpich/7.5.0
             mpich@7.5.0%cce@8.5.4 arch=cray-CNL-haswell: cray-mpich/7.5.0
         version: [7.5.0]
         buildable: False
@@ -45,6 +46,16 @@ packages:
             python@2.7.12: /apps/daint/UES/jenkins/6.0.UP02/mc/easybuild/software/Python/2.7.12-CrayGNU-2016.11
         version: [2.7.12]
         buildable: False
+    py-cython:
+        paths:
+            py-cython@0.24.1: /apps/daint/UES/jenkins/6.0.UP02/mc/easybuild/software/Python/2.7.12-CrayGNU-2016.11
+        buildable: False
+        version: [0.24.1]
+    gsl:
+        paths:
+            gsl@2.1: /apps/daint/UES/jenkins/6.0.UP02/mc/easybuild/software/GSL/2.1-CrayGNU-2016.11/
+        buildable: False
+        version: [2.1.0]
     mod2c:
         compiler: [gcc]
     nrnh5:


### PR DESCRIPTION
The fake intel compiler version is intel@17.0.0.999 
It automatically loads perftools modules for profiling on cray.
I propose to make all fake compilers for profiling end with version .999 
 
Added paths to py-cython and gsl required by nest and already provided by system.