### PR TITLE
Downgrade version of TAU/PDT for BBP systems because

### DIFF
--- a/bbpbgq/packages.yaml
+++ b/bbpbgq/packages.yaml
@@ -61,6 +61,10 @@ packages:
     tau:
         variants: ~comm ~phase
         version: [2.25.2]
+
+    pdt:
+        version: [3.22.1]
+
     gsl:
         paths:
             gsl@1.16: /gpfs/bbp.cscs.ch/apps/bgq/nix/nix-root/store/789cxs76pmxrk2n68z272jnd7mbb42rd-generated-env-module-gsl/

--- a/bbpviz/packages.yaml
+++ b/bbpviz/packages.yaml
@@ -65,7 +65,11 @@ packages:
         version: [1.2.8]
 
     tau:
+        version: [2.25.2]
         variants: ~openmp ~comm ~phase
+
+    pdt:
+        version: [3.22.1]
 
     coreneuron:
         variants: ~openmp


### PR DESCRIPTION
NEURON has problem compiling with latest TAU 2.26